### PR TITLE
Email failer fix

### DIFF
--- a/force-app/components/emailScheduling/classes/EmailSchedulingHelper.cls
+++ b/force-app/components/emailScheduling/classes/EmailSchedulingHelper.cls
@@ -43,7 +43,7 @@ public with sharing class EmailSchedulingHelper {
                 OR (EmailBeforeDate__c = TODAY
                 AND EmailBeforeSent__c = FALSE
                 AND EmailBeforeConfirmation__c = TRUE)
-                OR (EmailManualDate__c = LAST_N_DAYS:10
+                OR (EmailManualDate__c = TODAY
                 AND EmailManualSent__c = FALSE
                 AND EmailManualConfirmation__c = TRUE)
                 OR (EmailReminderDate__c = TODAY

--- a/force-app/main/default/objects/Course__c/fields/EmailAfterStatus__c.field-meta.xml
+++ b/force-app/main/default/objects/Course__c/fields/EmailAfterStatus__c.field-meta.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EmailAfterStatus__c</fullName>
     <externalId>false</externalId>
     <formula>IF ( EmailAfterSendDatePassed__c,
 
-IF ( EmailAfterConfirmation__c,
+        IF ( EmailAfterConfirmation__c,
 
-    IF ( EmailAfterSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent , 
+        IF ( EmailAfterSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent ,
 
-    IF ( TODAY() = EmailAfterDate__c, 
-        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;09:15:00.000&quot;),
-            &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
-            &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
+        IF ( TODAY() = EmailAfterDate__c,
+        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;18:00:00.000&quot;),
+        &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
+        &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
         &apos;❌ &apos; + $Label.EmailConfirmation_SendError)
-    ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
-&apos;&apos;)</formula>
+        ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
+        &apos;&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Status</label>
     <required>false</required>

--- a/force-app/main/default/objects/Course__c/fields/EmailBeforeStatus__c.field-meta.xml
+++ b/force-app/main/default/objects/Course__c/fields/EmailBeforeStatus__c.field-meta.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EmailBeforeStatus__c</fullName>
     <externalId>false</externalId>
     <formula>IF ( EmailBeforeSendDatePassed__c,
 
-IF ( EmailBeforeConfirmation__c,
+        IF ( EmailBeforeConfirmation__c,
 
-    IF ( EmailBeforeSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent , 
+        IF ( EmailBeforeSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent ,
 
-    IF ( TODAY() = EmailBeforeDate__c, 
-        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;09:15:00.000&quot;),
-            &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
-            &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
+        IF ( TODAY() = EmailBeforeDate__c,
+        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;18:00:00.000&quot;),
+        &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
+        &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
         &apos;❌ &apos; + $Label.EmailConfirmation_SendError)
-    ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
-&apos;&apos;)</formula>
+        ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
+        &apos;&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Status</label>
     <required>false</required>

--- a/force-app/main/default/objects/Course__c/fields/EmailManualStatus__c.field-meta.xml
+++ b/force-app/main/default/objects/Course__c/fields/EmailManualStatus__c.field-meta.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EmailManualStatus__c</fullName>
     <externalId>false</externalId>
     <formula>IF ( EmailManualSendDatePassed__c,
 
-IF ( EmailManualConfirmation__c,
+        IF ( EmailManualConfirmation__c,
 
-    IF ( EmailManualSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent , 
+        IF ( EmailManualSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent ,
 
-    IF ( TODAY() = EmailManualDate__c, 
-        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;09:15:00.000&quot;),
-            &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
-            &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
+        IF ( TODAY() = EmailManualDate__c,
+        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;18:00:00.000&quot;),
+        &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
+        &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
         &apos;❌ &apos; + $Label.EmailConfirmation_SendError)
-    ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
-&apos;&apos;)</formula>
+        ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
+        &apos;&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Status</label>
     <required>false</required>

--- a/force-app/main/default/objects/Course__c/fields/EmailReminderStatus__c.field-meta.xml
+++ b/force-app/main/default/objects/Course__c/fields/EmailReminderStatus__c.field-meta.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EmailReminderStatus__c</fullName>
     <externalId>false</externalId>
     <formula>IF ( EmailReminderSendDatePassed__c,
 
-IF ( EmailReminderConfirmation__c,
+        IF ( EmailReminderConfirmation__c,
 
-    IF ( EmailReminderSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent , 
+        IF ( EmailReminderSent__c, &apos;✅ &apos; + $Label.EmailConfirmation_Sent ,
 
-    IF ( TODAY() = EmailReminderDate__c, 
-        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;09:15:00.000&quot;),
-            &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
-            &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
+        IF ( TODAY() = EmailReminderDate__c,
+        IF ( TIMENOW() &gt;= TIMEVALUE(&quot;18:00:00.000&quot;),
+        &apos;❌ &apos; + $Label.EmailConfirmation_SendError,
+        &apos;⏳ &apos; + $Label.EmailConfirmation_Scheduled),
         &apos;❌ &apos; + $Label.EmailConfirmation_SendError)
-    ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
-&apos;&apos;)</formula>
+        ), &apos;💤 &apos; + $Label.EmailConfirmation_NotScheduled ),
+        &apos;&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Status</label>
     <required>false</required>


### PR DESCRIPTION
Endrer tilbake til TODAY, ettersom valg av epost template avhenger av hvilken dato utsendingsdatoen er satt til.

Endrer formelfelt til å heller vise en feilmelding om det ikke er blitt sendt før senere på dagen. Da vi legger opp til at batchen skal kjøre flere ganger enn den gjør nå.