### PR TITLE
TOLK 3096 : Fjern deaktiverte valideringsregler

### DIFF
--- a/force-app/main/default/objectTranslations/CourseRegistration__c-no/CourseRegistration__c-no.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/CourseRegistration__c-no/CourseRegistration__c-no.objectTranslation-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <article>Definite</article>
@@ -34,22 +34,16 @@
     <layouts>
         <layout>Course Registration Layout</layout>
         <sections>
-            <label><!-- Custom Links --></label>
+            <label><!-- Custom Links -->
+            </label>
             <section>Custom Links</section>
         </sections>
     </layouts>
     <nameFieldLabel>Kurspåmelding ID</nameFieldLabel>
     <validationRules>
-        <errorMessage><!-- Dette kurset er ikke aktivt --></errorMessage>
-        <name>Course_must_be_active</name>
-    </validationRules>
-    <validationRules>
-        <errorMessage
-        ><!-- Maks antall deltagere er registrert på dette kurset. Deltakeren må settes på venteliste. --></errorMessage>
+        <errorMessage><!-- Maks antall deltagere er registrert på dette kurset. Deltakeren må settes
+            på venteliste. -->
+        </errorMessage>
         <name>Do_not_exceed_max_number_of_participants</name>
-    </validationRules>
-    <validationRules>
-        <errorMessage><!-- Påmeldingsfristen har utløpt --></errorMessage>
-        <name>Do_not_exceed_registration_deadline</name>
     </validationRules>
 </CustomObjectTranslation>

--- a/force-app/main/default/objects/CourseRegistration__c/validationRules/Course_must_be_active.validationRule-meta.xml
+++ b/force-app/main/default/objects/CourseRegistration__c/validationRules/Course_must_be_active.validationRule-meta.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Course_must_be_active</fullName>
-    <active>false</active>
-    <errorConditionFormula>Course__r.Active__c = False</errorConditionFormula>
-    <errorMessage>Dette kurset er ikke aktivt</errorMessage>
-</ValidationRule>

--- a/force-app/main/default/objects/CourseRegistration__c/validationRules/Do_not_exceed_registration_deadline.validationRule-meta.xml
+++ b/force-app/main/default/objects/CourseRegistration__c/validationRules/Do_not_exceed_registration_deadline.validationRule-meta.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Do_not_exceed_registration_deadline</fullName>
-    <active>false</active>
-    <errorConditionFormula>Course__r.CreatedDate &gt;= Course__r.RegistrationDeadline__c</errorConditionFormula>
-    <errorMessage>Påmeldingsfristen har utløpt</errorMessage>
-</ValidationRule>


### PR DESCRIPTION
Deleted the inactive 'Course_must_be_active' and 'Do_not_exceed_registration_deadline' validation rules and updated the Norwegian object translation to reflect these removals.